### PR TITLE
Offer more run-time configuration options

### DIFF
--- a/lib/swagger-doc.js
+++ b/lib/swagger-doc.js
@@ -44,8 +44,8 @@ for (var i = 0; i < SWAGGER_METHODS.length; i++) {
 var swagger = module.exports = {};
 
 swagger.resources = [];
-
-swagger.nicknameCounter = 0;
+swagger.routeNames = {};
+swagger.hiddenPaths = [];
 
 swagger.configure = function(server, options) {
   options = options || {};
@@ -57,26 +57,41 @@ swagger.configure = function(server, options) {
   this.apiVersion = options.version || this.server.version || "0.1";
   this.basePath = options.basePath;
 
-  this.server.get(discoveryUrl, function(req, res, next) {
-    var result = self._createResponse(req);
-    result.apis = self.resources.map(function(r) { return {path: r.path, description: ""}; });
-
-    res.send(result);
-  });
+  this.routeNames[this.basePath] = this.server.get(discoveryUrl, self.discoveryRequest);
 };
+
+swagger.discoveryRequest = function(req, res, next) {
+  var result = swagger._createResponse(req);
+  result.apis = swagger.resources.map(function(r) { return {path: r.path, description: ""}; });
+
+  if (swagger.hiddenPaths.length > 0) {
+    for (var i = 0; i < swagger.hiddenPaths.length; i++) {
+      for (var j = 0; j < result.apis.length; j++) {
+        if (result.apis[j].path == swagger.hiddenPaths[i]) {
+          result.apis.splice(j, 1);
+          break;
+        }
+      }
+    }
+  }
+
+  res.send(result);
+  return next();
+}
 
 swagger.createResource = function(path) {
   var resource = new Resource(path),
       self = this;
   this.resources.push(resource);
 
-  this.server.get(path, function(req, res, next) {
+  swagger.routeNames[path] = this.server.get(path, function(req, res, next) {
     var result = self._createResponse(req);
     result.resourcePath = path;
     result.apis = Object.keys(resource.apis).map(function(k) { return resource.apis[k]; });
     result.models = resource.models;
 
     res.send(result);
+    return next();
   });
 
   return resource;
@@ -91,4 +106,6 @@ swagger._createResponse = function(req) {
   };
 };
 
-  
+swagger.hidePath = function(path) {
+  this.hiddenPaths.push(path);
+};


### PR DESCRIPTION
Storing the results of server.get into an object (swagger.routeNames), to make it easier to know the connection between a Swagger doc & the Express/Restify path.

Also introducing the capability, per-user, to hide certain routes. This has proven useful within server.use() to (for example) say "if user is admin, swagger.hiddenPaths = [], else swagger.hidePath("/control-panel")

(To accomplish this, I also had to pull the discoveryUrl route function out of the configure method.)
